### PR TITLE
Feat/challenges back

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ gem 'enumerize'
 gem 'jbuilder', '~> 2.7'
 gem 'marcel', '~> 1.0'
 gem 'pg'
-gem 'power-types'
 gem 'power_api', '~> 2.0'
+gem 'power-types'
 gem 'puma', '~> 5.0'
 gem 'pundit'
 gem 'rack-cors', '~> 1.1'
@@ -65,11 +65,4 @@ end
 
 group :production, :development, :test do
   gem 'tzinfo-data'
-end
-
-group :development, :test do
-  gem 'rubocop', '~> 1.9'
-  gem 'rubocop-performance'
-  gem 'rubocop-rails'
-  gem 'rubocop-rspec', '~> 2.2'
 end

--- a/app/admin/challenges.rb
+++ b/app/admin/challenges.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Challenge do
+  permit_params :title, :stack, :kind, :difficulty, :description, :link
+end

--- a/app/controllers/api/internal/challenges_controller.rb
+++ b/app/controllers/api/internal/challenges_controller.rb
@@ -1,0 +1,39 @@
+class Api::Internal::ChallengesController < Api::Internal::BaseController
+  def index
+    respond_with Challenge.all
+  end
+
+  def show
+    respond_with challenge
+  end
+
+  def create
+    respond_with Challenge.create!(challenge_params)
+  end
+
+  def update
+    challenge.update!(challenge_params)
+    respond_with challenge
+  end
+
+  def destroy
+    respond_with challenge.destroy!
+  end
+
+  private
+
+  def challenge
+    @challenge ||= Challenge.find_by!(id: params[:id])
+  end
+
+  def challenge_params
+    params.require(:challenge).permit(
+      :title,
+      :stack,
+      :kind,
+      :difficulty,
+      :description,
+      :link
+    )
+  end
+end

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -1,0 +1,34 @@
+class Challenge < ApplicationRecord
+  validates :title, :stack, :kind, :difficulty, :description, presence: true
+
+  enum stack: {
+    python: 0,
+    html: 1
+  }
+
+  enum kind: {
+    challenge: 0,
+    homework: 1
+  }
+
+  enum difficulty: {
+    easy: 0,
+    medium: 1,
+    hard: 2
+  }
+end
+
+# == Schema Information
+#
+# Table name: challenges
+#
+#  id          :bigint(8)        not null, primary key
+#  title       :string           not null
+#  stack       :integer          default("python"), not null
+#  kind        :integer          default("challenge"), not null
+#  difficulty  :integer          default("easy"), not null
+#  description :text             not null
+#  link        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/app/serializers/api/internal/challenge_serializer.rb
+++ b/app/serializers/api/internal/challenge_serializer.rb
@@ -1,0 +1,15 @@
+class Api::Internal::ChallengeSerializer < ActiveModel::Serializer
+  type :challenge
+
+  attributes(
+    :id,
+    :title,
+    :stack,
+    :kind,
+    :difficulty,
+    :description,
+    :link,
+    :created_at,
+    :updated_at
+  )
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   namespace :api, defaults: { format: :json } do
     namespace :internal do
+      resources :challenges
     end
   end
   devise_for :users

--- a/db/migrate/20220511140837_create_challenges.rb
+++ b/db/migrate/20220511140837_create_challenges.rb
@@ -1,0 +1,14 @@
+class CreateChallenges < ActiveRecord::Migration[6.1]
+  def change
+    create_table :challenges do |t|
+      t.string :title, null: false
+      t.integer :stack, null: false, default: 0
+      t.integer :kind, null: false, default: 0
+      t.integer :difficulty, null: false, default: 0
+      t.text :description, null: false
+      t.string :link
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_08_051412) do
+ActiveRecord::Schema.define(version: 2022_05_11_140837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,17 @@ ActiveRecord::Schema.define(version: 2022_04_08_051412) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "challenges", force: :cascade do |t|
+    t.string "title", null: false
+    t.integer "stack", default: 0, null: false
+    t.integer "kind", default: 0, null: false
+    t.integer "difficulty", default: 0, null: false
+    t.text "description", null: false
+    t.string "link"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "program_themes", force: :cascade do |t|

--- a/spec/factories/challenges.rb
+++ b/spec/factories/challenges.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :challenge do
+    title { "My Challenge" }
+    stack { 'python' }
+    kind { 'challenge' }
+    difficulty { 'easy' }
+    description { "In this Challenge you'll learn how to use print and inputs" }
+    link { 'link ' }
+  end
+end

--- a/spec/models/challenge_spec.rb
+++ b/spec/models/challenge_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Challenge, type: :model do
+  it 'has a valid factory' do
+    expect(build(:challenge)).to be_valid
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :title }
+    it { is_expected.to validate_presence_of :stack }
+    it { is_expected.to validate_presence_of :kind }
+    it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :difficulty }
+  end
+end

--- a/spec/requests/api/internal/challenges_spec.rb
+++ b/spec/requests/api/internal/challenges_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Internal::ChallengesControllers', type: :request do
+  describe 'GET /index' do
+    let!(:challenges) { create_list(:challenge, 5) }
+    let(:collection) { JSON.parse(response.body)['challenges'] }
+    let(:params) { {} }
+
+    def perform
+      get '/api/internal/challenges', params: params
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(collection.count).to eq(5) }
+    it { expect(response.status).to eq(200) }
+  end
+
+  describe 'POST /create' do
+    let(:params) do
+      {
+        challenge: {
+          title: 'Python Easy Challenge',
+          stack: 'python',
+          kind: 'challenge',
+          difficulty: 'easy',
+          description: 'Easy Challenge description',
+          link: 'easy challenge link'
+        }
+      }
+    end
+
+    let(:attributes) do
+      JSON.parse(response.body)['challenge'].symbolize_keys
+    end
+
+    def perform
+      post '/api/internal/challenges', params: params
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(attributes).to include(params[:challenge]) }
+    it { expect(response.status).to eq(201) }
+  end
+
+  describe 'GET /show' do
+    let(:challenge) { create(:challenge) }
+    let(:challenge_id) { challenge.id.to_s }
+
+    let(:attributes) do
+      JSON.parse(response.body)['challenge'].symbolize_keys
+    end
+
+    def perform
+      get "/api/internal/challenges/#{challenge_id}"
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(response.status).to eq(200) }
+
+    context 'with resource not found' do
+      let(:challenge_id) { '666' }
+
+      it { expect(response.status).to eq(404) }
+    end
+  end
+
+  describe 'PUT /update' do
+    let(:challenge) { create(:challenge) }
+    let(:challenge_id) { challenge.id.to_s }
+
+    let(:params) do
+      {
+        challenge: {
+          title: 'Medium Html Homework',
+          stack: 'html',
+          kind: 'homework',
+          difficulty: 'medium',
+          description: 'Medium homework description',
+          link: 'medium homework link'
+        }
+      }
+    end
+
+    let(:attributes) do
+      JSON.parse(response.body)['challenge'].symbolize_keys
+    end
+
+    def perform
+      put "/api/internal/challenges/#{challenge_id}", params: params
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(attributes).to include(params[:challenge]) }
+    it { expect(response.status).to eq(200) }
+
+    context 'with resource not found' do
+      let(:challenge_id) { '666' }
+
+      it { expect(response.status).to eq(404) }
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    let(:challenge) { create(:challenge) }
+    let(:challenge_id) { challenge.id.to_s }
+
+    def perform
+      get "/api/internal/challenges/#{challenge_id}"
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(response.status).to eq(200) }
+
+    context 'with resource not found' do
+      let(:challenge_id) { '666' }
+
+      it { expect(response.status).to eq(404) }
+    end
+  end
+end


### PR DESCRIPTION
### Contexto
La sección de desafíos tenía información harcodeada. Queremos que se pueda editar desde active admin
​
### Qué se esta haciendo
Se crea el modelo `Challenges` en back y su controller
​
#### En particular hay que revisar
- El modelo `Challenges`
- El controller `ChallengesController`. Aquí hay harto autogenerado por Power Api
​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
Así se ve en el admin :
![Captura de Pantalla 2022-05-11 a la(s) 12 52 43](https://user-images.githubusercontent.com/30674444/167904872-cf6dffc1-181a-4065-86b1-d71756aef3be.png)

