### PR TITLE
Feat/posts section mobile

### DIFF
--- a/app/javascript/components/landing/challenge-card.vue
+++ b/app/javascript/components/landing/challenge-card.vue
@@ -1,15 +1,15 @@
 <script setup lang='ts'>
 interface Props {
-  type: string,
+  kind: string,
   stack: string,
   title: string,
   difficulty: string,
   description: string,
-  link: string,
+  link?: string,
 }
 
 withDefaults(defineProps<Props>(), {
-  type: 'challenge',
+  kind: 'challenge',
   stack: 'python',
   title: 'Pizzapp',
   difficulty: 'easy',
@@ -29,7 +29,7 @@ const difficultyNames = {
   hard: 'alta',
 };
 
-const typeNames = {
+const kindNames = {
   challenge: 'Desafío',
   homework: 'Guía',
 };
@@ -40,7 +40,7 @@ const typeNames = {
   <div class="aspect-5/4 flex flex-col p-4 mx-2 min-w-[85%] bg-white rounded-3xl md:mx-0 md:w-full">
     <div class="flex flex-row justify-between w-full ">
       <div class="text-sm font-light text-gray-500">
-        {{ typeNames[type] }}
+        {{ kindNames[kind] }}
       </div>
       <div class="flex flex-row">
         <img

--- a/app/javascript/components/landing/landing-challenges.vue
+++ b/app/javascript/components/landing/landing-challenges.vue
@@ -42,6 +42,7 @@ onMounted(() => {
         v-for="challenge in challenges"
         :key="`challenge-cad-${challenge.id}`"
         :title="challenge.title"
+        :kind="challenge.kind"
         :stack="challenge.stack"
         :difficulty="challenge.difficulty"
         :description="challenge.description"

--- a/app/javascript/components/landing/landing-posts.vue
+++ b/app/javascript/components/landing/landing-posts.vue
@@ -10,12 +10,12 @@ const posts = [
 </script>
 
 <template>
-  <section class="flex relative flex-col items-center px-4 pb-14">
+  <section class="flex relative flex-col items-center px-4 pb-16 md:pb-14">
     <img
       :src="require('../../../assets/images/bee-path-2.svg')"
-      class="absolute left-0"
+      class="z-30 h-2/3 rotate-12 md:rotate-0 absolute -top-12 md:top-0 -left-16 md:-left-4 lg:left-0 md:h-auto"
     >
-    <div class="grid grid-cols-3 mt-28 w-[80%]">
+    <div class="mt-28 w-[80%] md:grid md:grid-cols-3">
       <post-card
         v-for="post in posts "
         :key="`news-card-${post.id}`"
@@ -26,7 +26,7 @@ const posts = [
     </div>
     <img
       :src="require('../../../assets/images/bee-path-3.svg')"
-      class="absolute right-0 -bottom-24"
+      class="z-30 h-2/3 absolute -right-64 md:-right-48 lg:right-0 -bottom-32 md:h-auto"
     >
   </section>
 </template>

--- a/app/javascript/components/landing/post-card.vue
+++ b/app/javascript/components/landing/post-card.vue
@@ -14,9 +14,9 @@ withDefaults(defineProps<Props>(), {
 });
 
 const variantStyles = {
-  left: '-rotate-25 mt-44',
+  left: '-rotate-25 mt-32 lg:mt-44 hidden md:block',
   center: 'z-10',
-  right: 'rotate-15 z-20',
+  right: 'rotate-15 z-20 hidden md:block',
 };
 
 </script>
@@ -28,11 +28,11 @@ const variantStyles = {
       <div class="aspect-square absolute z-0 w-full bg-slate-100 rounded-3xl shadow-xl -rotate-12" />
     </div>
     <div
-      class="flex relative flex-col p-5 w-full h-max bg-white rounded-3xl border border-slate-100 shadow-2xl"
+      class="flex relative flex-col items-center p-4 md:p-5 w-full h-max bg-white rounded-xl md:rounded-2xl lg:rounded-3xl border border-slate-100 shadow-2xl"
       :class="variantStyles[variant]"
     >
-      <div class="aspect-21/20 flex flex-col p-4 mx-2 mb-6 w-full bg-slate-200 rounded-3xl lg:mx-0" />
-      <div class="text-lg  text-slate-700">
+      <div class="aspect-21/20 flex flex-col p-4 mb-4 md:mb-6 w-full bg-slate-200 rounded-xl md:rounded-2xl lg:rounded-3xl " />
+      <div class="w-full text-left text-slate-700 md:text-base lg:text-lg">
         {{ title }}
       </div>
     </div>

--- a/app/javascript/components/shared/bichito-button.vue
+++ b/app/javascript/components/shared/bichito-button.vue
@@ -1,7 +1,7 @@
 <script setup lang='ts'>
 interface Props {
-  theme: string,
-  size: string,
+  theme?: string,
+  size?: string,
 }
 withDefaults(defineProps<Props>(), {
   theme: 'dark',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,6 @@ module.exports = {
       aspectRatio: {
         '21/20': '21 / 20',
         '5/4': '5 / 4',
-        '7/8': '7 / 8 ',
       },
       rotate: {
         '15': '15deg',


### PR DESCRIPTION
### Contexto
Faltaba aplicar el diseño de la sección de noticias o posts para pantallas chicas. 
​
### Qué se esta haciendo
- Se cambian los estilos para pantallas chicas. Se esconden los posts de los lados y se deja sólo el central.
- Se arreglan algunos detalles de props de otros componentes que generaban warnings
​
#### En particular hay que revisar
​Los cambios de estilo en los componentes `PostCard` y `LandingPosts` 

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)

**Figma:** 
https://www.figma.com/file/WHL8ql2TY8NgisCztGJuKN/Landing-Bichito?node-id=25%3A2

**Pantalla chica**
![Captura de Pantalla 2022-05-12 a la(s) 16 39 51](https://user-images.githubusercontent.com/30674444/168166219-9a3dbad1-548a-4dc4-a5f4-5af552ee474f.png)

*Web*
![Captura de Pantalla 2022-05-12 a la(s) 15 16 53](https://user-images.githubusercontent.com/30674444/168151620-7dd9c26b-617f-4f67-a760-0ae508afe222.png)

