### PR TITLE
Feat/posts back

### DIFF
--- a/app/admin/posts.rb
+++ b/app/admin/posts.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Post do
+  permit_params :title
+end

--- a/app/controllers/api/internal/posts_controller.rb
+++ b/app/controllers/api/internal/posts_controller.rb
@@ -1,0 +1,34 @@
+class Api::Internal::PostsController < Api::Internal::BaseController
+  def index
+    respond_with Post.all
+  end
+
+  def show
+    respond_with post
+  end
+
+  def create
+    respond_with Post.create!(post_params)
+  end
+
+  def update
+    post.update!(post_params)
+    respond_with post
+  end
+
+  def destroy
+    respond_with post.destroy!
+  end
+
+  private
+
+  def post
+    @post ||= Post.find_by!(id: params[:id])
+  end
+
+  def post_params
+    params.require(:post).permit(
+      :title
+    )
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,13 @@
+class Post < ApplicationRecord
+  validates :title, presence: true
+end
+
+# == Schema Information
+#
+# Table name: posts
+#
+#  id         :bigint(8)        not null, primary key
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/app/serializers/api/internal/post_serializer.rb
+++ b/app/serializers/api/internal/post_serializer.rb
@@ -1,0 +1,10 @@
+class Api::Internal::PostSerializer < ActiveModel::Serializer
+  type :post
+
+  attributes(
+    :id,
+    :title,
+    :created_at,
+    :updated_at
+  )
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   namespace :api, defaults: { format: :json } do
     namespace :internal do
+      resources :posts
       resources :challenges
     end
   end

--- a/db/migrate/20220512212530_create_posts.rb
+++ b/db/migrate/20220512212530_create_posts.rb
@@ -1,0 +1,9 @@
+class CreatePosts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :posts do |t|
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_11_140837) do
+ActiveRecord::Schema.define(version: 2022_05_12_212530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,12 @@ ActiveRecord::Schema.define(version: 2022_05_11_140837) do
     t.integer "difficulty", default: 0, null: false
     t.text "description", null: false
     t.string "link"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :post do
+    title { "My Post" }
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  it 'has a valid factory' do
+    expect(build(:post)).to be_valid
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :title }
+  end
+end

--- a/spec/requests/api/internal/challenges_spec.rb
+++ b/spec/requests/api/internal/challenges_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'Api::Internal::ChallengesControllers', type: :request do
     end
 
     it { expect(attributes).to include(params[:challenge]) }
+    it { expect { perform }.to change { Challenge.count }.by (1) }
     it { expect(response.status).to eq(201) }
   end
 
@@ -113,21 +114,29 @@ RSpec.describe 'Api::Internal::ChallengesControllers', type: :request do
   end
 
   describe 'DELETE /destroy' do
-    let(:challenge) { create(:challenge) }
+    let!(:challenge) { create(:challenge) }
     let(:challenge_id) { challenge.id.to_s }
 
     def perform
-      get "/api/internal/challenges/#{challenge_id}"
+      delete "/api/internal/challenges/#{challenge_id}"
     end
 
-    before do
-      perform
+    context 'with correct response status' do
+      before do
+        perform
+      end
+
+      it { expect(response.status).to eq(204) }
     end
 
-    it { expect(response.status).to eq(200) }
+    it { expect { perform }.to change { Challenge.count }.by (-1) }
 
     context 'with resource not found' do
       let(:challenge_id) { '666' }
+
+      before do
+        perform
+      end
 
       it { expect(response.status).to eq(404) }
     end

--- a/spec/requests/api/internal/posts_spec.rb
+++ b/spec/requests/api/internal/posts_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Internal::PostsControllers', type: :request do
+  describe 'GET /index' do
+    let!(:posts) { create_list(:post, 5) }
+    let(:collection) { JSON.parse(response.body)['posts'] }
+    let(:params) { {} }
+
+    def perform
+      get '/api/internal/posts', params: params
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(collection.count).to eq(5) }
+    it { expect(response.status).to eq(200) }
+  end
+
+  describe 'POST /create' do
+    let(:params) do
+      {
+        post: {
+          title: 'Post title'
+        }
+      }
+    end
+
+    let(:attributes) do
+      JSON.parse(response.body)['post'].symbolize_keys
+    end
+
+    def perform
+      post '/api/internal/posts', params: params
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(attributes).to include(params[:post]) }
+    it { expect { perform }.to change { Post.count }.by 1 }
+    it { expect(response.status).to eq(201) }
+
+    context 'with invalid attributes' do
+      let(:params) do
+        {
+          post: {
+            title: nil
+          }
+        }
+      end
+
+      it { expect(response.status).to eq(400) }
+    end
+  end
+
+  describe 'GET /show' do
+    let(:post) { create(:post) }
+    let(:post_id) { post.id.to_s }
+
+    let(:attributes) do
+      JSON.parse(response.body)['post'].symbolize_keys
+    end
+
+    def perform
+      get "/api/internal/posts/#{post_id}"
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(response.status).to eq(200) }
+
+    context 'with resource not found' do
+      let(:post_id) { '666' }
+
+      it { expect(response.status).to eq(404) }
+    end
+  end
+
+  describe 'PUT /update' do
+    let(:post) { create(:post) }
+    let(:post_id) { post.id.to_s }
+
+    let(:params) do
+      {
+        post: {
+          title: 'Post title'
+        }
+      }
+    end
+
+    let(:attributes) do
+      JSON.parse(response.body)['post'].symbolize_keys
+    end
+
+    def perform
+      put "/api/internal/posts/#{post_id}", params: params
+    end
+
+    before do
+      perform
+    end
+
+    it { expect(attributes).to include(params[:post]) }
+    it { expect(response.status).to eq(200) }
+
+    context 'with invalid attributes' do
+      let(:params) do
+        {
+          post: {
+            title: nil
+          }
+        }
+      end
+
+      it { expect(response.status).to eq(400) }
+    end
+
+    context 'with resource not found' do
+      let(:post_id) { '666' }
+
+      it { expect(response.status).to eq(404) }
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    let!(:post) { create(:post) }
+    let(:post_id) { post.id.to_s }
+
+    def perform
+      delete "/api/internal/posts/#{post_id}"
+    end
+
+    context 'with correct response status' do
+      before do
+        perform
+      end
+
+      it { expect(response.status).to eq(204) }
+    end
+
+    it { expect { perform }.to change { Post.count }.by (-1) }
+
+    context 'with resource not found' do
+      let(:post_id) { '666' }
+
+      before do
+        perform
+      end
+
+      it { expect(response.status).to eq(404) }
+    end
+  end
+end


### PR DESCRIPTION
### Contexto
Los posts de la landing están harcodeados en front están. Queremos poder modificarlos desde active admin.
​
### Qué se está haciendo
Se agregó el modelo y controller de los posts. Por ahora sólo tienen en título, en un próximo PR agregaré lo de la imagen.
​
#### En particular hay que revisar
- El nuevo modelo `Post` y su controlador
​
-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
En Active Admin:
![Captura de Pantalla 2022-05-13 a la(s) 10 05 19](https://user-images.githubusercontent.com/30674444/168301599-83ae9bad-3b77-4c69-9c33-95dbdcaf8494.png)

