### PR TITLE
Feat/load images

### DIFF
--- a/app/admin/posts.rb
+++ b/app/admin/posts.rb
@@ -1,3 +1,14 @@
 ActiveAdmin.register Post do
-  permit_params :title
+  permit_params :title, :image
+
+  form do |f|
+    f.semantic_errors
+
+    f.inputs do
+      f.input :title
+      f.input :image,  { as: :file }
+    end
+
+    f.actions
+  end
 end

--- a/app/javascript/api/index.ts
+++ b/app/javascript/api/index.ts
@@ -8,7 +8,7 @@ const api = axios.create({
 });
 
 api.interceptors.response.use((response: AxiosResponse) => {
-  if (response.data && response.headers['content-type'] === 'application/json') {
+  if (response.data && response.headers['content-type'].includes('application/json')) {
     response.data = camelizeKeys(response.data);
   }
 

--- a/app/javascript/components/landing/landing-posts.vue
+++ b/app/javascript/components/landing/landing-posts.vue
@@ -43,6 +43,7 @@ onMounted(() => {
         :key="`news-card-${post.id}`"
         :variant="POSTS_VARIANTS[id]"
         :title="post.title"
+        :image-url="post.imageUrl"
         :bg-cards="post.bgCards"
       />
     </div>

--- a/app/javascript/components/landing/post-card.vue
+++ b/app/javascript/components/landing/post-card.vue
@@ -1,14 +1,14 @@
 <script setup lang='ts'>
 interface Props {
   title: string,
-  image?: string,
+  imageUrl?: string,
   variant: string,
   bgCards: boolean,
 }
 
 withDefaults(defineProps<Props>(), {
   title: 'Actividad Bichito',
-  image: undefined,
+  imageUrl: undefined,
   variant: 'center',
   bgCards: false,
 });
@@ -28,10 +28,15 @@ const variantStyles = {
       <div class="aspect-square absolute z-0 w-full bg-slate-100 rounded-3xl shadow-xl -rotate-12" />
     </div>
     <div
-      class="flex relative flex-col items-center p-4 md:p-5 w-full h-max bg-white rounded-xl md:rounded-2xl lg:rounded-3xl border border-slate-100 shadow-2xl"
+      class="flex relative flex-col items-center p-4 md:p-5 w-full h-max bg-white rounded-xl lg:rounded-2xl border border-slate-100 shadow-2xl"
       :class="variantStyles[variant]"
     >
-      <div class="aspect-21/20 flex flex-col p-4 mb-4 md:mb-6 w-full bg-slate-200 rounded-xl md:rounded-2xl lg:rounded-3xl " />
+     <img
+        v-if="imageUrl"
+        :src="imageUrl"
+        class="object-cover aspect-21/20 flex flex-col mb-4 md:mb-6 w-full rounded-2xl "
+      > 
+      <div v-else class="aspect-21/20 flex flex-col p-4 mb-4 md:mb-6 w-full bg-slate-200 rounded-xl md:rounded-2xl " />
       <div class="w-full text-left text-slate-700 md:text-base lg:text-lg">
         {{ title }}
       </div>

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ApplicationRecord
+  include ImageUploader::Attachment(:image)
+
   validates :title, presence: true
 end
 
@@ -10,4 +12,5 @@ end
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  image_data :jsonb
 #

--- a/app/serializers/api/internal/post_serializer.rb
+++ b/app/serializers/api/internal/post_serializer.rb
@@ -4,6 +4,7 @@ class Api::Internal::PostSerializer < ActiveModel::Serializer
   attributes(
     :id,
     :title,
+    :image_url,
     :created_at,
     :updated_at
   )

--- a/db/migrate/20220513191504_add_image_data_to_posts.rb
+++ b/db/migrate/20220513191504_add_image_data_to_posts.rb
@@ -1,0 +1,5 @@
+class AddImageDataToPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :posts, :image_data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_12_212530) do
+ActiveRecord::Schema.define(version: 2022_05_13_191504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2022_05_12_212530) do
     t.string "title", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.jsonb "image_data"
   end
 
   create_table "program_themes", force: :cascade do |t|


### PR DESCRIPTION
### Contexto
En Bichito hay una sección de posts en que se deberían mostrar imágenes
​
### Qué se esta haciendo
- Se agrega el campo de imágenes a los posts y se usa en front
- Se arregla un pequeño error en el interceptor de la api de front, que no estaba camelizando las keys
​
#### En particular hay que revisar
- El modelo `Post` en que se agregó el campo `image_data` y se usa el `ImageUploader`
- El componente `PostCard`, en que ahora se muestra la imagen cuando la hay


-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)

**Pantalla grande**
![Captura de Pantalla 2022-05-13 a la(s) 17 30 47](https://user-images.githubusercontent.com/30674444/168392547-62a28d08-71fe-422e-9fed-81ae21e04d00.png)

**Pantalla chica**

![Captura de Pantalla 2022-05-13 a la(s) 17 30 56](https://user-images.githubusercontent.com/30674444/168392571-b6cbacc1-1a54-4a9d-9861-aed551e49311.png)
