### PR TITLE
fix(): add declaration of module

### DIFF
--- a/app/javascript/types/humps.d.ts
+++ b/app/javascript/types/humps.d.ts
@@ -1,0 +1,1 @@
+declare module 'humps'


### PR DESCRIPTION
### Contexto
​Había un error con el modulo humps ya que faltaba declararlo en types.

### Qué se esta haciendo
​Se agrega el archivos humps.d.ts para declarar el modulo

#### En particular hay que revisar
​humps.d.ts
