### PR TITLE
chore(heroku): potassium install heroku

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,3 @@
+https://github.com/heroku/heroku-buildpack-nodejs
+https://github.com/platanus/heroku-buildpack-ruby-version.git
+https://github.com/heroku/heroku-buildpack-ruby.git

--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,11 @@ end
 group :production, :development, :test do
   gem 'tzinfo-data'
 end
+
+group :production do
+  gem 'heroku-stage'
+  gem 'rails_stdout_logging'
+end
+
+group :production do
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
     has_scope (0.8.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
+    heroku-stage (0.4.0)
+      rails
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.13.1)
@@ -325,6 +327,7 @@ GEM
     rails-i18n (7.0.3)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_stdout_logging (0.0.5)
     railties (6.1.5)
       actionpack (= 6.1.5)
       activesupport (= 6.1.5)
@@ -511,6 +514,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   guard-rspec
+  heroku-stage
   jbuilder (~> 2.7)
   listen
   marcel (~> 1.0)
@@ -525,6 +529,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 6.1.5)
   rails-i18n
+  rails_stdout_logging
   rspec-nc
   rspec-rails
   rspec_junit_formatter (~> 0.4)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C ./config/puma.rb
+release: bin/release

--- a/README.md
+++ b/README.md
@@ -165,3 +165,30 @@ For even faster in-place component refreshing (with no page reloads), you can en
       dev_server:
         hmr: true
 
+
+## Deployment
+
+This project is pre-configured to be (easily) deployed to Heroku servers, but needs you to have the Potassium binary installed. If you don't, then run:
+
+    $ gem install potassium
+
+Then, make sure you are logged in to the Heroku account where you want to create the app and run
+
+    $ potassium install heroku --force
+
+this will create the app on heroku, create a pipeline and link the app to the pipeline.
+
+You'll still have to manually log in to the heroku dahsboard, go to the new pipeline and 'configure automatic deploys' using Github
+You can run the following command to open the dashboard in the pipeline page
+
+    $ heroku pipelines:open
+
+![Hint](https://cloud.githubusercontent.com/assets/313750/13019759/fa86c8ca-d1af-11e5-8869-cd2efb5513fa.png)
+
+Remember to connect each stage to the corresponding branch:
+
+1. Staging -> Master
+2. Production -> Production
+
+That's it. You should already have a running app and each time you push to the corresponding branch, the system will (hopefully) update accordingly.
+

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo 'Release Phase...'
+
+bundle exec rails db:migrate:with_data
+
+echo 'Release Phase: OK'

--- a/bin/setup_heroku
+++ b/bin/setup_heroku
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Setup heroku application remotes
+if heroku auth:whoami &> /dev/null; then
+  if heroku apps:info --app  pl-bichito-platform-staging &> /dev/null; then
+    git remote add staging git@heroku.com:pl-bichito-platform-staging.git || true
+    git config heroku.remote staging
+    echo 'You are a collaborator on the "pl-bichito-platform" Heroku app'
+  else
+    echo 'Ask for access to the "pl-bichito-platform" Heroku app'
+  fi
+
+  if heroku apps:info --app  pl-bichito-platform-production &> /dev/null; then
+    git remote add production git@heroku.com:pl-bichito-platform-production.git || true
+    echo 'You are a collaborator on the "pl-bichito-platform-production" Heroku app'
+  else
+    echo 'Ask for access to the "pl-bichito-platform-production" Heroku app'
+  fi
+else
+  echo 'You need to login to heroku. Run "heroku login"'
+fi


### PR DESCRIPTION
### Contexto
La app no estaba conectada a un pipeline de heroku.
​
### Qué se esta haciendo
- Se corrió `potassium install heroku`
- Algunas cosas no funcionaron pero rellené el `bin/heroku_setup` viendo otros proyectos
- Ahora corriendo bin/setup_heroku se crean los remotes creados a las apps de staging y production
​
#### En particular hay que revisar
`bin/setup_heroku`: es el único que no se terminó con potassium entero y algo me podría haber quedado mal

​

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)