### PR TITLE
fix(): add missing member migration

### DIFF
--- a/db/migrate/20220728205741_change_members_columns_not_null.rb
+++ b/db/migrate/20220728205741_change_members_columns_not_null.rb
@@ -1,0 +1,9 @@
+class ChangeMembersColumnsNotNull < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      change_column_null :members, :name, false
+      change_column_null :members, :description, false
+      change_column_null :members, :role, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_22_174039) do
+ActiveRecord::Schema.define(version: 2022_07_28_205741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
### Contexto
​Se esta desarrollando la landing para bichito. La idea inicial de esta landing tenía un enfoque más para los alumnos y se decidió cambiar el enfoque para que apuntara a los responsables de los colegios/cursos que estuvieran interesados en el programa. Una de las secciones cuenta con los miembros de Bichito y para cada uno de ellos se muestra su nombre, rol una imagen y una descripción.

### Qué se esta haciendo
Faltaba la migración para hacer que los​ atributos de los miembros del equipo, el nombre, el rol y la descripción fueran obligatorias. La imagen no es ya que hay una que se posiciona por default.

#### En particular hay que revisar
​La migración para hacer este cambio db/migrate/20220728205741_change_members_columns_not_null.rb
